### PR TITLE
Disable GCP workflow from automatic CI

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -6,12 +6,7 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  workflow_call:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:  # Manual trigger only (cloud publishing disabled for CI)
 
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,10 @@ jobs:
     uses: ./.github/workflows/compose.yml
   gate-minikube:
     uses: ./.github/workflows/minikube.yml
-  gate-gcp:
-    uses: ./.github/workflows/gcp.yml
-    secrets: inherit
-
   # 1. Create the Draft Release immediately
   create-draft:
     name: Create Draft Release
-    needs: [gate-backend, gate-docker, gate-compose, gate-minikube, gate-gcp]
+    needs: [gate-backend, gate-docker, gate-compose, gate-minikube]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## Summary
- GCP deployment workflow changed to manual-only (`workflow_dispatch`)
- Removed GCP gate from release workflow
- Prevents PRs from being blocked by missing cloud credentials

## Test plan
- [x] Other workflows (backend, docker, compose, minikube) unaffected
- [x] GCP can still be triggered manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)