### PR TITLE
[FEATURE] Integrate validation into solver and server (#34)

### DIFF
--- a/sbs-backend/src/bin/server.rs
+++ b/sbs-backend/src/bin/server.rs
@@ -1,12 +1,12 @@
 //! REST API Service for Spelling Bee Solver.
 //!
 //! Endpoints:
-//! - POST /solve: Accepts JSON config, returns word list.
+//! - POST /solve: Accepts JSON config, returns word list (or enriched entries with validator).
 //! - GET /health: Status check.
 
 use actix_cors::Cors;
 use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
-use sbs::{Config, Dictionary, Solver};
+use sbs::{create_validator, Config, Dictionary, Solver};
 use std::env;
 use std::sync::Arc;
 
@@ -24,13 +24,13 @@ async fn health() -> impl Responder {
 async fn solve_puzzle(data: web::Data<AppState>, config_json: web::Json<Config>) -> impl Responder {
     let config = config_json.into_inner();
 
-    // We run the solver logic. Since it's CPU bound, for very large dictionaries
-    // or heavy load, we might use web::block, but Trie traversal is usually fast enough (ms).
-
-    // Validate basics
     if config.letters.is_none() || config.present.is_none() {
         return HttpResponse::BadRequest().body("Missing letters or present char");
     }
+
+    let validator_kind = config.validator.clone();
+    let api_key = config.api_key.clone();
+    let validator_url = config.validator_url.clone();
 
     let solver = Solver::new(config);
 
@@ -38,7 +38,31 @@ async fn solve_puzzle(data: web::Data<AppState>, config_json: web::Json<Config>)
         Ok(words) => {
             let mut sorted: Vec<String> = words.into_iter().collect();
             sorted.sort();
-            HttpResponse::Ok().json(sorted)
+
+            // If a validator is specified, enrich results with definitions and URLs
+            if let Some(kind) = validator_kind {
+                let validator =
+                    match create_validator(&kind, api_key.as_deref(), validator_url.as_deref()) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return HttpResponse::BadRequest().body(e.to_string());
+                        }
+                    };
+
+                let mut entries = Vec::new();
+                for word in &sorted {
+                    match validator.lookup(word) {
+                        Ok(Some(entry)) => entries.push(entry),
+                        Ok(None) => {} // Word not found in validator, skip
+                        Err(e) => {
+                            log::warn!("Validation error for '{}': {}", word, e);
+                        }
+                    }
+                }
+                HttpResponse::Ok().json(entries)
+            } else {
+                HttpResponse::Ok().json(sorted)
+            }
         }
         Err(e) => HttpResponse::InternalServerError().body(e.to_string()),
     }
@@ -48,8 +72,6 @@ async fn solve_puzzle(data: web::Data<AppState>, config_json: web::Json<Config>)
 async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
-    // Load dictionary path from env or default
-    // Note: In a real deployment, we might pass this via CLI args to the server binary too.
     let dict_path = env::var("SBS_DICT").unwrap_or_else(|_| "data/dictionary.txt".to_string());
 
     log::info!("Loading dictionary from: {}", dict_path);
@@ -65,7 +87,7 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(move || {
         App::new()
-            .wrap(Cors::permissive()) // Allow requests from GUI
+            .wrap(Cors::permissive())
             .app_data(web::Data::new(AppState {
                 dictionary: dictionary.clone(),
             }))

--- a/sbs-backend/src/config.rs
+++ b/sbs-backend/src/config.rs
@@ -1,6 +1,7 @@
 //! Configuration management.
 
 use crate::error::SbsError;
+use crate::validator::ValidatorKind;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -34,6 +35,13 @@ pub struct Config {
 
     // External APIs for validation
     pub external_dictionaries: Option<Vec<DictionaryConfig>>,
+
+    // Validator selection
+    pub validator: Option<ValidatorKind>,
+    #[serde(rename = "api-key")]
+    pub api_key: Option<String>,
+    #[serde(rename = "validator-url")]
+    pub validator_url: Option<String>,
 }
 
 fn default_dict_path() -> PathBuf {
@@ -52,6 +60,9 @@ impl Config {
             repeats: None,
             dictionary: default_dict_path(),
             external_dictionaries: None,
+            validator: None,
+            api_key: None,
+            validator_url: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Added `validator`, `api_key`, `validator_url` fields to `Config`
- Server returns `WordEntry[]` (word + definition + url) when validator is specified
- Backward compatible: returns plain `String[]` when no validator is set

## Test plan
- [x] `cargo test` — 10 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — formatted

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)