### PR TITLE
[FEATURE] Add validator dropdown to frontend GUI (#36)

### DIFF
--- a/sbs-frontend/src/App.tsx
+++ b/sbs-frontend/src/App.tsx
@@ -5,13 +5,29 @@ interface SolveRequest {
   letters: string;
   present: string;
   repeats: number | null;
+  validator?: string;
+  "api-key"?: string;
+  "validator-url"?: string;
+}
+
+interface WordEntry {
+  word: string;
+  definition: string;
+  url: string;
+}
+
+type ResultItem = string | WordEntry;
+
+function isWordEntry(item: ResultItem): item is WordEntry {
+  return typeof item === 'object' && 'word' in item && 'definition' in item && 'url' in item;
 }
 
 function App() {
   const [letters, setLetters] = useState('')
   const [present, setPresent] = useState('')
   const [repeats, setRepeats] = useState('')
-  const [results, setResults] = useState<string[]>([])
+  const [validator, setValidator] = useState('')
+  const [results, setResults] = useState<ResultItem[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -21,20 +37,22 @@ function App() {
     setResults([]);
 
     try {
-      // Relative URL:
-      // - In Local Dev: Vite proxies this to localhost:8080
-      // - In Cloud Prod: Nginx proxies this to backend-service
       const payload: SolveRequest = {
         letters: letters,
         present: present,
         repeats: repeats ? parseInt(repeats) : null
       };
-      
+
+      if (validator) {
+        payload.validator = validator;
+      }
+
       const response = await axios.post('/solve', payload);
       setResults(response.data);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to connect to backend';
       console.error(err);
-      setError(err.message || 'Failed to connect to backend');
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -45,11 +63,11 @@ function App() {
   return (
     <div className="container">
       <h1 style={{textAlign: 'center', marginBottom: '1.5rem'}}>Spelling Bee Solver</h1>
-      
+
       <div className="input-group">
         <label>Available Letters</label>
-        <input 
-          placeholder="e.g. abcdefg" 
+        <input
+          placeholder="e.g. abcdefg"
           value={letters}
           onChange={(e) => setLetters(e.target.value)}
         />
@@ -57,8 +75,8 @@ function App() {
 
       <div className="input-group">
         <label>Obligatory Letter</label>
-        <input 
-          placeholder="e.g. a" 
+        <input
+          placeholder="e.g. a"
           value={present}
           onChange={(e) => setPresent(e.target.value)}
         />
@@ -66,12 +84,22 @@ function App() {
 
       <div className="input-group">
         <label>Max Repeats (Optional)</label>
-        <input 
+        <input
           type="number"
-          placeholder="Unlimited" 
+          placeholder="Unlimited"
           value={repeats}
           onChange={(e) => setRepeats(e.target.value)}
         />
+      </div>
+
+      <div className="input-group">
+        <label>Dictionary Validator (Optional)</label>
+        <select value={validator} onChange={(e) => setValidator(e.target.value)}>
+          <option value="">None (seed dictionary only)</option>
+          <option value="free-dictionary">Free Dictionary</option>
+          <option value="merriam-webster">Merriam-Webster</option>
+          <option value="wordnik">Wordnik</option>
+        </select>
       </div>
 
       <button onClick={handleSolve} disabled={!isValid || loading}>
@@ -82,9 +110,19 @@ function App() {
 
       <div className="results">
         {results.length > 0 && <h3>Found {results.length} words:</h3>}
-        {results.map((word) => (
-          <div key={word} className="word-card">{word}</div>
-        ))}
+        {results.map((item) => {
+          if (isWordEntry(item)) {
+            return (
+              <div key={item.word} className="word-card">
+                <a href={item.url} target="_blank" rel="noopener noreferrer" className="word-link">
+                  {item.word}
+                </a>
+                <span className="word-definition">{item.definition}</span>
+              </div>
+            );
+          }
+          return <div key={item} className="word-card">{item}</div>;
+        })}
       </div>
     </div>
   )

--- a/sbs-frontend/src/index.css
+++ b/sbs-frontend/src/index.css
@@ -23,13 +23,14 @@ label {
   font-weight: 500;
   color: #333;
 }
-input {
+input, select {
   width: 100%;
   padding: 0.75rem;
   border: 1px solid #ddd;
   border-radius: 4px;
   font-size: 1rem;
-  box-sizing: border-box; 
+  box-sizing: border-box;
+  background-color: white;
 }
 button {
   width: 100%;
@@ -58,6 +59,21 @@ button:disabled {
   margin-bottom: 0.5rem;
   border-radius: 4px;
   border: 1px solid #eee;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.word-link {
+  color: #007bff;
+  text-decoration: none;
+  font-weight: 600;
+}
+.word-link:hover {
+  text-decoration: underline;
+}
+.word-definition {
+  color: #666;
+  font-size: 0.9rem;
 }
 .error {
   color: #dc3545;


### PR DESCRIPTION
## Summary
- Added dropdown selector for dictionary validator (None, Free Dictionary, Merriam-Webster, Wordnik)
- Results display as hyperlinked words with definitions when validator is active
- Plain word cards when no validator selected (backward compatible)
- New CSS styles for select elements, word links, and definitions

## Test plan
- [x] `npm run build` — builds without errors
- [x] Backward compatible: no validator = plain word list
- [x] With validator: enriched word cards with links and definitions

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)