### PR TITLE
[FEATURE] Support custom validator URL (#37)

### DIFF
--- a/sbs-frontend/src/App.tsx
+++ b/sbs-frontend/src/App.tsx
@@ -27,6 +27,7 @@ function App() {
   const [present, setPresent] = useState('')
   const [repeats, setRepeats] = useState('')
   const [validator, setValidator] = useState('')
+  const [validatorUrl, setValidatorUrl] = useState('')
   const [results, setResults] = useState<ResultItem[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -45,6 +46,9 @@ function App() {
 
       if (validator) {
         payload.validator = validator;
+        if (validator === 'custom' && validatorUrl) {
+          payload["validator-url"] = validatorUrl;
+        }
       }
 
       const response = await axios.post('/solve', payload);
@@ -99,8 +103,20 @@ function App() {
           <option value="free-dictionary">Free Dictionary</option>
           <option value="merriam-webster">Merriam-Webster</option>
           <option value="wordnik">Wordnik</option>
+          <option value="custom">Custom URL</option>
         </select>
       </div>
+
+      {validator === 'custom' && (
+        <div className="input-group">
+          <label>Custom Validator URL</label>
+          <input
+            placeholder="e.g. https://api.dictionaryapi.dev/api/v2/entries/en"
+            value={validatorUrl}
+            onChange={(e) => setValidatorUrl(e.target.value)}
+          />
+        </div>
+      )}
 
       <button onClick={handleSolve} disabled={!isValid || loading}>
         {loading ? 'Solving...' : 'Solve'}


### PR DESCRIPTION
## Summary
- Added "Custom URL" option to the validator dropdown in the GUI
- When selected, a text input appears for the custom API URL
- URL is sent to backend as `validator-url` parameter
- Backend probe mechanism validates the URL before use (from #33)
- CLI already supports `--validator custom --validator-url <URL>` (from #35)

## Test plan
- [x] Frontend builds without errors
- [x] Custom URL input shown/hidden based on dropdown selection
- [x] Backend probe validates custom URLs

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)