### PR TITLE
Fix medium and low priority polish items

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ make minikube-delete
 
 ![Cloud](architecture/cloud.png)
 
-Deploy the stack to a GCP (Google Clopud Platform) Kubernetes cluster using the followng make targets.
+Deploy the stack to a GCP (Google Cloud Platform) Kubernetes cluster using the followng make targets.
 
 **Note**  
 Requires `GCP_PROJECT_ID`, `GCP_CLUSTER_NAME`, and `GCP_ZONE` environment variables to be set to appropriate values.

--- a/charts/gcp/README.md
+++ b/charts/gcp/README.md
@@ -10,7 +10,7 @@
 
 ### 1. Authenticate with GKE
 ```bash
-gcloud container clusters get-credentials sbs-cluster --zone europe-west6-a --project sbs-solver
+gcloud container clusters get-credentials $GCP_CLUSTER_NAME --zone $GCP_ZONE --project $GCP_PROJECT_ID
 ```
 
 ### 2. Build and Push Images
@@ -20,16 +20,16 @@ export CLOUD_TAG=$(git rev-parse --short HEAD)
 
 # Build for linux/amd64 (required for GKE)
 docker build --platform linux/amd64 \
-  -t gcr.io/sbs-solver/sbs-backend:$CLOUD_TAG \
+  -t gcr.io/$GCP_PROJECT_ID/sbs-backend:$CLOUD_TAG \
   -f sbs-backend/Dockerfile sbs-backend
 
 docker build --platform linux/amd64 \
-  -t gcr.io/sbs-solver/sbs-frontend:$CLOUD_TAG \
+  -t gcr.io/$GCP_PROJECT_ID/sbs-frontend:$CLOUD_TAG \
   -f sbs-frontend/Dockerfile sbs-frontend
 
 # Push to GCR
-docker push gcr.io/sbs-solver/sbs-backend:$CLOUD_TAG
-docker push gcr.io/sbs-solver/sbs-frontend:$CLOUD_TAG
+docker push gcr.io/$GCP_PROJECT_ID/sbs-backend:$CLOUD_TAG
+docker push gcr.io/$GCP_PROJECT_ID/sbs-frontend:$CLOUD_TAG
 ```
 
 ### 3. Deploy with Helm

--- a/sbs-backend/src/config.rs
+++ b/sbs-backend/src/config.rs
@@ -11,13 +11,6 @@ const DEFAULT_SIZE: usize = 7;
 const DEFAULT_DICT_PATH: &str = "data/dictionary.txt";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct DictionaryConfig {
-    pub id: String,
-    pub name: String,
-    pub api: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub letters: Option<String>,
     pub present: Option<String>, // The obligatory letter(s)
@@ -32,9 +25,6 @@ pub struct Config {
     // Path to the seed dictionary for generation
     #[serde(default = "default_dict_path")]
     pub dictionary: PathBuf,
-
-    // External APIs for validation
-    pub external_dictionaries: Option<Vec<DictionaryConfig>>,
 
     // Validator selection
     pub validator: Option<ValidatorKind>,
@@ -59,7 +49,6 @@ impl Config {
             output: None,
             repeats: None,
             dictionary: default_dict_path(),
-            external_dictionaries: None,
             validator: None,
             api_key: None,
             validator_url: None,

--- a/sbs-frontend/src/App.tsx
+++ b/sbs-frontend/src/App.tsx
@@ -28,6 +28,7 @@ function App() {
   const [repeats, setRepeats] = useState('')
   const [validator, setValidator] = useState('')
   const [validatorUrl, setValidatorUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
   const [results, setResults] = useState<ResultItem[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -49,6 +50,9 @@ function App() {
         if (validator === 'custom' && validatorUrl) {
           payload["validator-url"] = validatorUrl;
         }
+        if ((validator === 'merriam-webster' || validator === 'wordnik') && apiKey) {
+          payload["api-key"] = apiKey;
+        }
       }
 
       const response = await axios.post('/solve', payload);
@@ -66,7 +70,7 @@ function App() {
 
   return (
     <div className="container">
-      <h1 style={{textAlign: 'center', marginBottom: '1.5rem'}}>Spelling Bee Solver</h1>
+      <h1 className="title">Spelling Bee Solver</h1>
 
       <div className="input-group">
         <label>Available Letters</label>
@@ -114,6 +118,18 @@ function App() {
             placeholder="e.g. https://api.dictionaryapi.dev/api/v2/entries/en"
             value={validatorUrl}
             onChange={(e) => setValidatorUrl(e.target.value)}
+          />
+        </div>
+      )}
+
+      {(validator === 'merriam-webster' || validator === 'wordnik') && (
+        <div className="input-group">
+          <label>API Key</label>
+          <input
+            type="password"
+            placeholder="Enter your API key"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
           />
         </div>
       )}

--- a/sbs-frontend/src/index.css
+++ b/sbs-frontend/src/index.css
@@ -14,6 +14,10 @@ body {
   width: 100%;
   max-width: 500px;
 }
+.title {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
 .input-group {
   margin-bottom: 1rem;
 }
@@ -31,6 +35,10 @@ input, select {
   font-size: 1rem;
   box-sizing: border-box;
   background-color: white;
+}
+input:focus, select:focus, button:focus {
+  outline: 2px solid #0056b3;
+  outline-offset: 2px;
 }
 button {
   width: 100%;


### PR DESCRIPTION
## Summary
- Removed unused `DictionaryConfig` struct and `external_dictionaries` field from config
- Added API key input field to GUI (shown for Merriam-Webster and Wordnik)
- Replaced hardcoded GCP project ID with environment variables in `charts/gcp/README.md`
- Fixed typo "Clopud" → "Cloud" in README
- Replaced inline styles with `.title` CSS class
- Added `:focus` states for inputs, selects, and buttons (accessibility)

## Test plan
- [x] `cargo test` — 10 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — formatted
- [x] `npm run build` — frontend builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)