### PR TITLE
Add robustness improvements: timeouts, throttling, error handling

### DIFF
--- a/sbs-backend/src/bin/server.rs
+++ b/sbs-backend/src/bin/server.rs
@@ -49,17 +49,14 @@ async fn solve_puzzle(data: web::Data<AppState>, config_json: web::Json<Config>)
                         }
                     };
 
-                let mut entries = Vec::new();
-                for word in &sorted {
-                    match validator.lookup(word) {
-                        Ok(Some(entry)) => entries.push(entry),
-                        Ok(None) => {} // Word not found in validator, skip
-                        Err(e) => {
-                            log::warn!("Validation error for '{}': {}", word, e);
-                        }
-                    }
-                }
-                HttpResponse::Ok().json(entries)
+                let summary = validator.validate_words(&sorted);
+                log::info!(
+                    "Validated: {} candidates, {} confirmed by {}",
+                    summary.candidates,
+                    summary.validated,
+                    kind.display_name()
+                );
+                HttpResponse::Ok().json(summary)
             } else {
                 HttpResponse::Ok().json(sorted)
             }

--- a/sbs-backend/src/config.rs
+++ b/sbs-backend/src/config.rs
@@ -7,14 +7,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_MIN_LENGTH: usize = 4;
-const DEFAULT_SIZE: usize = 7;
 const DEFAULT_DICT_PATH: &str = "data/dictionary.txt";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub letters: Option<String>,
     pub present: Option<String>, // The obligatory letter(s)
-    pub size: Option<usize>,
     #[serde(rename = "minimal-word-length")]
     pub minimal_word_length: Option<usize>,
     #[serde(rename = "maximal-word-length")]
@@ -43,7 +41,6 @@ impl Config {
         Self {
             letters: None,
             present: None,
-            size: Some(DEFAULT_SIZE),
             minimal_word_length: Some(DEFAULT_MIN_LENGTH),
             maximal_word_length: None,
             output: None,

--- a/sbs-backend/src/lib.rs
+++ b/sbs-backend/src/lib.rs
@@ -12,5 +12,5 @@ pub use error::SbsError;
 pub use solver::Solver;
 pub use validator::{
     create_validator, CustomValidator, FreeDictionaryValidator, MerriamWebsterValidator,
-    ValidatorKind, WordEntry, WordnikValidator,
+    ValidationSummary, ValidatorKind, WordEntry, WordnikValidator,
 };


### PR DESCRIPTION
## Summary
- Add 10s HTTP timeout for all validator API requests
- Add 100ms throttle delay between consecutive API calls to avoid rate limiting
- Introduce `ValidationSummary` struct with candidate/validated counts and `validate_words()` trait method
- Remove unused `size` field from `Config`
- Fix `unwrap()` panics in CLI output with proper error handling
- Add word count feedback in CLI (stderr), server logs, and frontend UI ("from N candidates")
- Add `MockValidator` and 7 new integration tests for validation logic

## Test plan
- [x] All 19 backend tests pass
- [x] Clippy clean (no warnings)
- [x] Frontend builds successfully
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)