### PR TITLE
Support multiple required letters

### DIFF
--- a/sbs-backend/src/solver.rs
+++ b/sbs-backend/src/solver.rs
@@ -141,6 +141,22 @@ mod tests {
     }
 
     #[test]
+    fn test_solver_multiple_required_letters() {
+        let config = Config::new().with_letters("abcdefg").with_present("af");
+
+        let solver = Solver::new(config);
+        let dict = Dictionary::from_words(&["fade", "faced", "bead", "cafe", "face"]);
+
+        let results = solver.solve(&dict).expect("Solver failed");
+
+        assert!(results.contains("fade"), "contains both a and f");
+        assert!(results.contains("faced"), "contains both a and f");
+        assert!(results.contains("cafe"), "contains both a and f");
+        assert!(results.contains("face"), "contains both a and f");
+        assert!(!results.contains("bead"), "missing f");
+    }
+
+    #[test]
     fn test_solver_min_length() {
         let mut config = Config::new().with_letters("abcde").with_present("a");
         config.minimal_word_length = Some(5);

--- a/sbs-frontend/src/App.tsx
+++ b/sbs-frontend/src/App.tsx
@@ -75,13 +75,15 @@ function App() {
   const handleLettersChange = (value: string) => {
     const unique = [...new Set(value.split(''))].join('');
     setLetters(unique);
-    if (present && !unique.includes(present)) setPresent('');
+    const filtered = present.split('').filter(c => unique.includes(c)).join('');
+    if (filtered !== present) setPresent(filtered);
     clearResults();
   };
 
   const handlePresentChange = (value: string) => {
-    if (value.length === 0 || letters.includes(value)) {
-      setPresent(value);
+    const unique = [...new Set(value.split(''))].join('');
+    if (unique.split('').every(c => letters.includes(c))) {
+      setPresent(unique);
       clearResults();
     }
   };
@@ -246,9 +248,9 @@ function App() {
       </div>
 
       <div className="input-group">
-        <label>Required Letter</label>
+        <label>Required Letters</label>
         <input
-          placeholder={letters.length > 0 ? `e.g. ${letters[0]}` : ''}
+          placeholder={letters.length > 1 ? `e.g. ${letters[0]} or ${letters.slice(0, 2)}` : ''}
           value={present}
           onChange={(e) => handlePresentChange(e.target.value)}
         />

--- a/sbs-mobile/App.tsx
+++ b/sbs-mobile/App.tsx
@@ -65,15 +65,17 @@ function App() {
   const handleLettersChange = (value: string) => {
     const unique = [...new Set(value.split(''))].join('');
     setLetters(unique);
-    if (present && !unique.includes(present)) {
-      setPresent('');
+    const filtered = present.split('').filter(c => unique.includes(c)).join('');
+    if (filtered !== present) {
+      setPresent(filtered);
     }
     clearResults();
   };
 
   const handlePresentChange = (value: string) => {
-    if (value.length === 0 || letters.includes(value)) {
-      setPresent(value);
+    const unique = [...new Set(value.split(''))].join('');
+    if (unique.split('').every(c => letters.includes(c))) {
+      setPresent(unique);
       clearResults();
     }
   };

--- a/sbs-mobile/__tests__/components/LetterInput.test.tsx
+++ b/sbs-mobile/__tests__/components/LetterInput.test.tsx
@@ -21,7 +21,7 @@ describe('LetterInput', () => {
     });
     const inputs = tree!.root.findAllByType('TextInput' as any);
     const presentInput = inputs[1];
-    expect(presentInput.props.placeholder).toBe('e.g. a');
+    expect(presentInput.props.placeholder).toBe('e.g. a or ab');
   });
 
   it('shows empty placeholder when no letters', async () => {

--- a/sbs-mobile/src/components/LetterInput.tsx
+++ b/sbs-mobile/src/components/LetterInput.tsx
@@ -34,16 +34,15 @@ export default function LetterInput({
       </View>
 
       <View style={styles.inputGroup}>
-        <Text style={styles.label}>Required Letter</Text>
+        <Text style={styles.label}>Required Letters</Text>
         <TextInput
           style={styles.input}
-          placeholder={letters.length > 0 ? `e.g. ${letters[0]}` : ''}
+          placeholder={letters.length > 1 ? `e.g. ${letters[0]} or ${letters.slice(0, 2)}` : ''}
           placeholderTextColor="#999"
           value={present}
           onChangeText={onPresentChange}
           autoCapitalize="none"
           autoCorrect={false}
-          maxLength={1}
         />
       </View>
 


### PR DESCRIPTION
## Summary

Closes #61. Removes the single-character constraint on the required letters input across all UIs.

- **Web frontend**: Accept multi-character input, deduplicate, validate each char is in available letters. Filter present when letters change (instead of clearing).
- **Mobile app**: Same logic. Remove `maxLength={1}` from `LetterInput`.
- **Placeholder**: Updated to hint at multi-letter input (e.g. `a or ab`).
- **Backend/CLI**: Already supported, no changes needed.
- **Tests**: Add solver test for multiple required letters. Update LetterInput placeholder test.

## Files changed

| Area | Files |
|---|---|
| Web | `sbs-frontend/src/App.tsx` |
| Mobile | `sbs-mobile/App.tsx`, `sbs-mobile/src/components/LetterInput.tsx` |
| Tests | `sbs-backend/src/solver.rs`, `sbs-mobile/__tests__/components/LetterInput.test.tsx` |

## Test plan

- [x] `cargo test` — 24 backend tests pass (including new multi-required test)
- [x] `cargo test` (sbs-ffi) — 23 FFI tests pass
- [x] `npm run build` (frontend) — compiles
- [x] `npx jest` (mobile) — 33 tests pass
- [ ] Manual: type multiple required letters, verify only valid chars accepted
- [ ] Manual: remove a letter from available, verify it's removed from required

🤖 Generated with [Claude Code](https://claude.com/claude-code)