### PR TITLE
Add CLI progress indicator during dictionary validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ CLAUDE_AUDIT.md
 
 # Secrets
 .env
+*.key
 
 # Node / React
 node_modules/

--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ make test-mobile
 sbs --about
 
 sbs: Spelling Bee Solver tool
-├─ version:   0.7.0
+├─ version:   0.7.1
 ├─ developer: mailto:waclaw.kusnierczyk@gmail.com
 ├─ source:    https://github.com/wkusnierczyk/spelling-bee-solver
 ├─ licence:   MIT https://opensource.org/licenses/MIT

--- a/charts/gcp/Chart.yaml
+++ b/charts/gcp/Chart.yaml
@@ -3,4 +3,4 @@ name: sbs-gcp
 description: GKE Helm chart for Spelling Bee Solver
 type: application
 version: 1.0.0
-appVersion: "0.7.0"
+appVersion: "0.7.1"

--- a/charts/minikube/Chart.yaml
+++ b/charts/minikube/Chart.yaml
@@ -3,4 +3,4 @@ name: sbs-server
 description: A Helm chart for the Spelling Bee Solver Service
 type: application
 version: 0.1.0
-appVersion: "0.7.0"
+appVersion: "0.7.1"

--- a/sbs-backend/Cargo.lock
+++ b/sbs-backend/Cargo.lock
@@ -1465,7 +1465,7 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "sbs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/sbs-backend/Cargo.toml
+++ b/sbs-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Your Name <your.email@example.com>"]
 description = "Spelling Bee Solver Core Library"

--- a/sbs-backend/src/main.rs
+++ b/sbs-backend/src/main.rs
@@ -15,9 +15,19 @@ use std::process;
 #[command(disable_version_flag = true)]
 #[command(about = "Spelling Bee Solver tool", long_about = None)]
 struct Args {
-    #[arg(short = 'a', long = "available-letters", alias = "available", alias = "letters")]
+    #[arg(
+        short = 'a',
+        long = "available-letters",
+        alias = "available",
+        alias = "letters"
+    )]
     available_letters: Option<String>,
-    #[arg(short = 'r', long = "required-letters", alias = "required", alias = "present")]
+    #[arg(
+        short = 'r',
+        long = "required-letters",
+        alias = "required",
+        alias = "present"
+    )]
     required_letters: Option<String>,
     #[arg(short, long)]
     config: Option<PathBuf>,
@@ -163,9 +173,12 @@ fn main() {
                         }
                     };
 
-                let summary = validator.validate_words(&sorted_words);
+                let summary =
+                    validator.validate_words_with_progress(&sorted_words, &|done, total| {
+                        eprint!("\rValidating: {}/{}", done, total);
+                    });
                 eprintln!(
-                    "Generated {} candidates, {} validated by {}.",
+                    "\rGenerated {} candidates, {} validated by {}.",
                     summary.candidates,
                     summary.validated,
                     kind.display_name()

--- a/sbs-ffi/Cargo.lock
+++ b/sbs-ffi/Cargo.lock
@@ -1236,7 +1236,7 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "sbs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "sbs-ffi"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "sbs",
  "serde",

--- a/sbs-ffi/Cargo.toml
+++ b/sbs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbs-ffi"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "FFI bindings for Spelling Bee Solver"
 

--- a/sbs-frontend/package.json
+++ b/sbs-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sbs-gui",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/sbs-mobile/android/app/build.gradle
+++ b/sbs-mobile/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "0.7.0"
+        versionName "0.7.1"
         ndk {
             abiFilters 'arm64-v8a', 'x86_64', 'armeabi-v7a'
         }

--- a/sbs-mobile/package.json
+++ b/sbs-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sbsmobile",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Summary
- Show `Validating: N/M` on stderr during CLI dictionary validation, overwritten in-place
- Final summary line replaces the progress output
- Uses the existing `validate_words_with_progress` callback
- Adds `*.key` to `.gitignore`

## Test plan
- [x] Backend tests pass (32 tests)
- [x] Manual test: `sbs -a abcde -r a --validator free-dictionary --minimal-word-length 5` shows progress
- [x] Verify progress overwrites cleanly in terminal

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)